### PR TITLE
Enhance Excel import for existing portfolio status

### DIFF
--- a/src/components/ProductSelector/ProductManager.tsx
+++ b/src/components/ProductSelector/ProductManager.tsx
@@ -109,20 +109,25 @@ const ProductManager: React.FC<ProductManagerProps> = ({
   };
 
   const handleCopyProductToRecommended = (excelProduct: any) => {
+    const notesParts = [
+      excelProduct.planName ? `תוכנית: ${excelProduct.planName}` : '',
+      excelProduct.policyNumber ? `פוליסה: ${excelProduct.policyNumber}` : ''
+    ].filter(Boolean);
+
     const product: SelectedProduct = {
       id: `${Date.now()}`,
-      company: excelProduct.manufacturer || '',
-      productName: excelProduct.productName || excelProduct.product || excelProduct.productType,
-      subType: '',
+      company: excelProduct.manufacturer || excelProduct.productType || 'לא צוין',
+      productName: excelProduct.productName || excelProduct.product || excelProduct.productType || 'מוצר',
+      subType: excelProduct.planName || excelProduct.productType || '',
       amount: excelProduct.accumulation || excelProduct.premium || 0,
       managementFeeOnDeposit: excelProduct.depositFee || 0,
       managementFeeOnAccumulation: excelProduct.accumulationFee || 0,
       investmentTrack: excelProduct.investmentTrack || '',
       riskLevelChange: '',
-      notes: `העתק מ: ${excelProduct.policyNumber || 'מצב קיים'}`,
+      notes: notesParts.length ? notesParts.join(' | ') : 'הועתק ממצב קיים',
       type: 'recommended'
     };
-    
+
     onUpdateProducts([...allProducts, product]);
   };
 


### PR DESCRIPTION
## Summary
- refine the Excel import pipeline to read the required savings and insurance columns from the dedicated tabs and normalise numeric values
- surface plan, manufacturer and policy metadata in the current-state dashboard and selection lists for a clearer existing portfolio summary
- carry the imported metadata into duplicated products so the existing editing flow remains consistent between current and proposed states

## Testing
- `npm run lint` *(fails: existing lint issues across the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68cc468d2adc832cb3d2a575c69fb814