### PR TITLE
Revamp final summary report output

### DIFF
--- a/src/components/AppForm.tsx
+++ b/src/components/AppForm.tsx
@@ -44,6 +44,7 @@ interface FormData {
   clientPhone: string;
   clientEmail: string;
   meetingDate: string;
+  meetingLocation: string;
   topics: string[];
   
   // Agent recommendations
@@ -82,6 +83,7 @@ const AppForm = () => {
     clientPhone: "",
     clientEmail: "",
     meetingDate: new Date().toISOString().split('T')[0],
+    meetingLocation: "",
     topics: [],
     currentSituation: "",
     risks: "",
@@ -598,6 +600,17 @@ const AppForm = () => {
                       value={formData.meetingDate}
                       onChange={(e) => setFormData(prev => ({ ...prev, meetingDate: e.target.value }))}
                       className="mt-2 bg-input rounded-xl"
+                    />
+                  </div>
+
+                  <div className="md:col-span-2">
+                    <Label htmlFor="meetingLocation">מיקום / אופי הפגישה</Label>
+                    <Input
+                      id="meetingLocation"
+                      value={formData.meetingLocation}
+                      onChange={(e) => setFormData(prev => ({ ...prev, meetingLocation: e.target.value }))}
+                      className="mt-2 bg-input rounded-xl"
+                      placeholder="למשל: פגישה במשרד, זום, טלפונית"
                     />
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- add meeting location capture to the client details form so the redesigned summary can display it consistently.
- rework PDF export to render the same structured report layout used in the app via a temporary React root.
- import React DOM utilities needed for the new export flow and keep the closing section aligned with the on-screen summary.

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce74abd5f4832c9402bc5ae7fb9e6d